### PR TITLE
Rename CI workflow to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@
 #
 #    maturin generate-ci github
 #
-name: CI
+name: Build wheels
 
 on:
   push:
@@ -12,7 +12,6 @@ on:
       - master
     tags:
       - '*'
-  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Also stop running on `pull_request` events.