### PR TITLE
Handle directory traversal attacks in safe_join

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "miette",
  "num-bigint",
  "pyo3",
+ "sugar_path",
  "thiserror",
  "unicode-xid",
 ]
@@ -342,6 +343,12 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "sugar_path"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8230d5b8a65a6d4d4a7e5ee8dbdd9312ba447a8b8329689a390a0945d69b57ce"
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ encoding_rs = "0.8.35"
 miette = { version = "7.2.0", features = ["fancy"] }
 num-bigint = "0.4.6"
 pyo3 = { version = "0.22.0", features = ["num-bigint"] }
+sugar_path = "1.2.0"
 thiserror = "1.0.64"
 unicode-xid = "0.2.6"


### PR DESCRIPTION
Add dependency on `sugar_path` for the `normalize` method, which removes `..` without the final path needing to exist. We require this to match the Django algorithm, which allows returning a path that doesn't exist. In `FileSystemLoader` we rely on `safe_join` to return paths that don't exist so we can report them in `LoaderError.tried`.

Fixes #6.