### PR TITLE
Use miette to generate fancy TemplateSyntaxError messages

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -118,8 +118,8 @@ pub mod django_rusty_templates {
         }
 
         #[allow(clippy::wrong_self_convention)] // We're implementing a Django interface
-        fn from_string(&self, template_code: String) -> PyResult<Template> {
-            Template::from_str(&template_code)
+        fn from_string(&self, template_code: Bound<'_, PyString>) -> PyResult<Template> {
+            Template::from_str(template_code.extract()?)
         }
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -119,7 +119,7 @@ pub mod django_rusty_templates {
 
         #[allow(clippy::wrong_self_convention)] // We're implementing a Django interface
         fn from_string(&self, template_code: Bound<'_, PyString>) -> PyResult<Template> {
-            Template::from_str(template_code.extract()?)
+            Template::from_string_inner(template_code.extract()?)
         }
     }
 
@@ -142,11 +142,11 @@ pub mod django_rusty_templates {
             })
         }
 
-        fn from_str(template: &str) -> PyResult<Self> {
-            let mut parser = Parser::new(template);
+        fn from_string_inner(template: String) -> PyResult<Self> {
+            let mut parser = Parser::new(&template);
             let nodes = parser.parse().unwrap();
             Ok(Self {
-                template: template.to_string(),
+                template,
                 filename: None,
                 nodes,
             })
@@ -169,8 +169,7 @@ pub mod django_rusty_templates {
     impl Template {
         #[staticmethod]
         pub fn from_string(template: Bound<'_, PyString>) -> PyResult<Self> {
-            let template = template.extract::<&str>()?;
-            Self::from_str(template)
+            Self::from_string_inner(template.extract()?)
         }
 
         #[pyo3(signature = (context=None, request=None))]

--- a/src/template.rs
+++ b/src/template.rs
@@ -162,7 +162,12 @@ pub mod django_rusty_templates {
 
         fn from_string_inner(template: String) -> PyResult<Self> {
             let mut parser = Parser::new(&template);
-            let nodes = parser.parse().unwrap();
+            let nodes = match parser.parse() {
+                Ok(nodes) => nodes,
+                Err(err) => {
+                    return Err(TemplateSyntaxError::with_source_code(err.into(), template));
+                }
+            };
             Ok(Self {
                 template,
                 filename: None,

--- a/src/template.rs
+++ b/src/template.rs
@@ -130,7 +130,7 @@ pub mod django_rusty_templates {
 
         #[allow(clippy::wrong_self_convention)] // We're implementing a Django interface
         pub fn from_string(&self, template_code: Bound<'_, PyString>) -> PyResult<Template> {
-            Template::from_string_inner(template_code.extract()?)
+            Template::new_from_string(template_code.extract()?)
         }
     }
 
@@ -160,7 +160,7 @@ pub mod django_rusty_templates {
             })
         }
 
-        fn from_string_inner(template: String) -> PyResult<Self> {
+        fn new_from_string(template: String) -> PyResult<Self> {
             let mut parser = Parser::new(&template);
             let nodes = match parser.parse() {
                 Ok(nodes) => nodes,
@@ -192,7 +192,7 @@ pub mod django_rusty_templates {
     impl Template {
         #[staticmethod]
         pub fn from_string(template: Bound<'_, PyString>) -> PyResult<Self> {
-            Self::from_string_inner(template.extract()?)
+            Self::new_from_string(template.extract()?)
         }
 
         #[pyo3(signature = (context=None, request=None))]

--- a/src/template.rs
+++ b/src/template.rs
@@ -116,6 +116,11 @@ pub mod django_rusty_templates {
             }
             Err(TemplateDoesNotExist::new_err((template_name, tried)))
         }
+
+        #[allow(clippy::wrong_self_convention)] // We're implementing a Django interface
+        fn from_string(&self, template_code: String) -> PyResult<Template> {
+            Template::from_str(&template_code)
+        }
     }
 
     #[derive(Clone, Debug)]

--- a/tests/templates/parse_error.txt
+++ b/tests/templates/parse_error.txt
@@ -1,0 +1,1 @@
+This is an empty variable: {{ }}

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+from textwrap import dedent
+
 import pytest
+from django.template.exceptions import TemplateSyntaxError
 from django.template.loader import get_template
 
 
@@ -10,3 +14,19 @@ def render(template, context, *, using):
 def test_render_template():
     context = {"user": "Lily"}
     assert render("basic.txt", context, using="rusty") == render("basic.txt", context, using="django")
+
+
+def test_parse_error():
+    with pytest.raises(TemplateSyntaxError) as excinfo:
+        get_template("parse_error.txt", using="rusty")
+
+    template_dir = Path("tests/templates").absolute()
+    expected = """\
+  × Empty variable tag
+   ╭─[%s/parse_error.txt:1:28]
+ 1 │ This is an empty variable: {{ }}
+   ·                            ──┬──
+   ·                              ╰── here
+   ╰────
+""" % template_dir
+    assert str(excinfo.value) == expected

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+from django.template import engines
 from django.template.exceptions import TemplateSyntaxError
 from django.template.loader import get_template
 
@@ -29,4 +30,26 @@ def test_parse_error():
    ·                              ╰── here
    ╰────
 """ % template_dir
+    assert str(excinfo.value) == expected
+
+
+def test_parse_error_from_string():
+    rusty_engine = engines["rusty"]
+
+    template = """
+This is an invalid filter name: {{ variable|'invalid'|title }}
+"""
+
+    with pytest.raises(TemplateSyntaxError) as excinfo:
+        rusty_engine.from_string(template)
+
+    expected = """\
+  × Expected a valid filter name
+   ╭─[2:45]
+ 1 │\x20
+ 2 │ This is an invalid filter name: {{ variable|'invalid'|title }}
+   ·                                             ────┬────
+   ·                                                 ╰── here
+   ╰────
+"""
     assert str(excinfo.value) == expected


### PR DESCRIPTION
Also add `Engine::from_string` to match Django's interface for template engines.