### PR TITLE
Set NO_COLOR during tests to avoid ansi codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "pyo3",
  "quickcheck",
  "sugar_path",
+ "temp-env",
  "thiserror",
  "unicode-xid",
 ]
@@ -157,6 +158,16 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -267,6 +278,29 @@ name = "owo-colors"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -386,6 +420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +475,18 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smawk"
@@ -482,6 +537,15 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "terminal_size"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ encoding_rs = "0.8.35"
 miette = { version = "7.2.0", features = ["fancy"] }
 num-bigint = "0.4.6"
 pyo3 = { version = "0.23.1", features = ["num-bigint"] }
-quickcheck = "1.0.3"
 sugar_path = "1.2.0"
-temp-env = "0.3.6"
 thiserror = "1.0.64"
 unicode-xid = "0.2.6"
+
+[dev-dependencies]
+
+quickcheck = "1.0.3"
+temp-env = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ num-bigint = "0.4.6"
 pyo3 = { version = "0.23.1", features = ["num-bigint"] }
 quickcheck = "1.0.3"
 sugar_path = "1.2.0"
+temp-env = "0.3.6"
 thiserror = "1.0.64"
 unicode-xid = "0.2.6"

--- a/src/template.rs
+++ b/src/template.rs
@@ -243,7 +243,9 @@ mod tests {
         );
 
         let template_string = std::fs::read_to_string(&filename).unwrap();
-        let error = Template::new(&template_string, filename).unwrap_err();
+        let error = temp_env::with_var("NO_COLOR", Some("1"), || {
+            Template::new(&template_string, filename).unwrap_err()
+        });
 
         let error_string = format!("{error}");
         assert_eq!(error_string, expected);
@@ -254,7 +256,9 @@ mod tests {
         pyo3::prepare_freethreaded_python();
 
         let template_string = "{{ foo.bar|title'foo' }}".to_string();
-        let error = Template::new_from_string(template_string).unwrap_err();
+        let error = temp_env::with_var("NO_COLOR", Some("1"), || {
+            Template::new_from_string(template_string).unwrap_err()
+        });
 
         let expected = "TemplateSyntaxError:   × Could not parse the remainder
    ╭────


### PR DESCRIPTION
These tests could emit ansi codes depending on whether the terminal
supports them.