### PR TITLE
Add `default` and `lower` filters

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -433,6 +433,14 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_argument_invalid_number() {
+        let template = "{{ foo|bar:9.9.9 }}";
+        let mut parser = Parser::new(template);
+        let error = parser.parse().unwrap_err();
+        assert_eq!(error, ParseError::InvalidNumber { at: (11, 5).into() });
+    }
+
+    #[test]
     fn test_filter_default() {
         let template = "{{ foo|default:baz }}";
         let mut parser = Parser::new(template);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -95,8 +95,6 @@ pub enum TokenTree {
     Tag(Tag),
     Variable(Variable),
     Filter(Box<Filter>),
-    Float(f64),
-    Int(BigInt),
 }
 
 #[derive(Error, Debug, Diagnostic, PartialEq, Eq)]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -15,7 +15,7 @@ pub struct Variable {
 }
 
 impl<'t> Variable {
-    fn new(at: (usize, usize)) -> Self {
+    pub fn new(at: (usize, usize)) -> Self {
         Self { at }
     }
 
@@ -36,7 +36,7 @@ pub struct Text {
 }
 
 impl<'t> Text {
-    fn new(at: (usize, usize)) -> Self {
+    pub fn new(at: (usize, usize)) -> Self {
         Self { at }
     }
 
@@ -60,7 +60,7 @@ pub struct Filter {
 }
 
 impl Filter {
-    fn new(
+    pub fn new(
         template: &str,
         at: (usize, usize),
         left: TokenTree,

--- a/src/render.rs
+++ b/src/render.rs
@@ -4,13 +4,25 @@ use std::collections::HashMap;
 use num_bigint::BigInt;
 use pyo3::prelude::*;
 
-use crate::parse::{Filter, FilterType, TokenTree, Variable};
+use crate::parse::{Argument, ArgumentType, Filter, FilterType, TokenTree, Variable};
 
 pub enum Content<'t, 'py> {
     Py(Bound<'py, PyAny>),
     String(Cow<'t, str>),
     Float(f64),
     Int(BigInt),
+}
+
+impl<'t> Content<'t, '_> {
+    fn render(self) -> PyResult<Cow<'t, str>> {
+        let content = match self {
+            Self::Py(content) => content.str()?.extract::<String>()?,
+            Self::String(content) => return Ok(content),
+            Self::Float(content) => content.to_string(),
+            Self::Int(content) => content.to_string(),
+        };
+        Ok(Cow::Owned(content))
+    }
 }
 
 pub trait Render {
@@ -84,13 +96,17 @@ impl Render for Filter {
         context: &HashMap<String, Bound<'py, PyAny>>,
     ) -> PyResult<Option<Content<'t, 'py>>> {
         let left = self.left.resolve(py, template, context)?;
-        match &self.filter {
+        Ok(match &self.filter {
             FilterType::Default(right) => match left {
-                Some(left) => Ok(Some(left)),
-                None => Ok(right.resolve(py, template, context)?),
+                Some(left) => Some(left),
+                None => right.resolve(py, template, context)?,
             },
             FilterType::External(_filter) => todo!(),
-        }
+            FilterType::Lower => match left {
+                Some(content) => Some(Content::String(Cow::Owned(content.render()?.to_lowercase()))),
+                None => Some(Content::String(Cow::Borrowed(""))),
+            }
+        })
     }
 }
 
@@ -112,6 +128,25 @@ impl Render for TokenTree {
             TokenTree::Float(number) => Ok(Some(Content::Float(*number))),
             TokenTree::Int(number) => Ok(Some(Content::Int(number.clone()))),
         }
+    }
+}
+
+impl Render for Argument {
+    fn resolve<'t, 'py>(
+        &self,
+        py: Python<'py>,
+        template: &'t str,
+        context: &HashMap<String, Bound<'py, PyAny>>,
+    ) -> PyResult<Option<Content<'t, 'py>>> {
+        Ok(Some(match &self.argument_type {
+            ArgumentType::Text(text) => {
+                Content::String(Cow::Borrowed(text.content(template)))
+            }
+            ArgumentType::TranslatedText(_text) => todo!(),
+            ArgumentType::Variable(variable) => return variable.resolve(py, template, context),
+            ArgumentType::Float(number) => Content::Float(*number),
+            ArgumentType::Int(number) => Content::Int(number.clone()),
+        }))
     }
 }
 
@@ -211,7 +246,7 @@ user = User('Lily')
                 template,
                 (8, 7),
                 TokenTree::Variable(variable),
-                Some(TokenTree::Text(Text::new((17, 6)))),
+                Some(Argument { at: (16, 8), argument_type: ArgumentType::Text(Text::new((17, 6)))}),
             ).unwrap();
 
             let rendered = filter.render(py, template, &context).unwrap();
@@ -231,7 +266,7 @@ user = User('Lily')
                 template,
                 (8, 7),
                 TokenTree::Variable(variable),
-                Some(TokenTree::Text(Text::new((17, 6)))),
+                Some(Argument{ at: (16, 8), argument_type: ArgumentType::Text(Text::new((17, 6)))}),
             ).unwrap();
 
             let rendered = filter.render(py, template, &context).unwrap();
@@ -251,7 +286,7 @@ user = User('Lily')
                 template,
                 (9, 7),
                 TokenTree::Variable(variable),
-                Some(TokenTree::Int(12.into())),
+                Some(Argument { at: (17, 2), argument_type: ArgumentType::Int(12.into())}),
             ).unwrap();
 
             let rendered = filter.render(py, template, &context).unwrap();
@@ -271,11 +306,32 @@ user = User('Lily')
                 template,
                 (9, 7),
                 TokenTree::Variable(variable),
-                Some(TokenTree::Float(3.5)),
+                Some(Argument{ at: (17, 3), argument_type: ArgumentType::Float(3.5)}),
             ).unwrap();
 
             let rendered = filter.render(py, template, &context).unwrap();
             assert_eq!(rendered, "3.5");
+        })
+    }
+
+    #[test]
+    fn test_render_filter_lower() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
+            let name = PyString::new(py, "Lily").into_any();
+            let context = HashMap::from([("name".to_string(), name)]);
+            let template = "{{ name|lower }}";
+            let variable = Variable::new((3, 4));
+            let filter = Filter::new(
+                template,
+                (8, 5),
+                TokenTree::Variable(variable),
+                None,
+            ).unwrap();
+
+            let rendered = filter.render(py, template, &context).unwrap();
+            assert_eq!(rendered, "lily");
         })
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -120,8 +120,6 @@ impl Render for TokenTree {
             TokenTree::Tag(_tag) => todo!(),
             TokenTree::Variable(variable) => variable.resolve(py, template, context),
             TokenTree::Filter(filter) => filter.resolve(py, template, context),
-            TokenTree::Float(number) => Ok(Some(Content::Float(*number))),
-            TokenTree::Int(number) => Ok(Some(Content::Int(number.clone()))),
         }
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -310,6 +310,27 @@ user = User('Lily')
     }
 
     #[test]
+    fn test_render_filter_default_variable() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
+            let me = PyString::new(py, "Lily").into_any();
+            let context = HashMap::from([("me".to_string(), me)]);
+            let template = "{{ name|default:me}}";
+            let variable = Variable::new((3, 4));
+            let filter = Filter::new(
+                template,
+                (8, 7),
+                TokenTree::Variable(variable),
+                Some(Argument{ at: (16, 2), argument_type: ArgumentType::Variable(Variable::new((16, 2)))}),
+            ).unwrap();
+
+            let rendered = filter.render(py, template, &context).unwrap();
+            assert_eq!(rendered, "Lily");
+        })
+    }
+
+    #[test]
     fn test_render_filter_lower() {
         pyo3::prepare_freethreaded_python();
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -329,4 +329,24 @@ user = User('Lily')
             assert_eq!(rendered, "lily");
         })
     }
+
+    #[test]
+    fn test_render_filter_lower_missing_left() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
+            let context = HashMap::new();
+            let template = "{{ name|lower }}";
+            let variable = Variable::new((3, 4));
+            let filter = Filter::new(
+                template,
+                (8, 5),
+                TokenTree::Variable(variable),
+                None,
+            ).unwrap();
+
+            let rendered = filter.render(py, template, &context).unwrap();
+            assert_eq!(rendered, "");
+        })
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -368,4 +368,30 @@ user = User('Lily')
             assert_eq!(rendered, "");
         })
     }
+
+    #[test]
+    fn test_render_chained_filters() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
+            let context = HashMap::new();
+            let template = "{{ name|default:'Bryony'|lower }}";
+            let variable = Variable::new((3, 4));
+            let default = Filter::new(
+                template,
+                (8, 7),
+                TokenTree::Variable(variable),
+                Some(Argument { at: (16, 8), argument_type: ArgumentType::Text(Text::new((17, 6)))}),
+            ).unwrap();
+            let lower = Filter::new(
+                template,
+                (25, 5),
+                TokenTree::Filter(Box::new(default)),
+                None,
+            ).unwrap();
+
+            let rendered = lower.render(py, template, &context).unwrap();
+            assert_eq!(rendered, "bryony");
+        })
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -40,12 +40,7 @@ pub trait Render {
         context: &HashMap<String, Bound<'py, PyAny>>,
     ) -> PyResult<Cow<'t, str>> {
         let content = match self.resolve(py, template, context) {
-            Ok(Some(content)) => match content {
-                Content::Py(content) => content.str()?.extract::<String>()?,
-                Content::String(content) => return Ok(content),
-                Content::Float(content) => return Ok(Cow::Owned(content.to_string())),
-                Content::Int(content) => return Ok(Cow::Owned(content.to_string())),
-            },
+            Ok(Some(content)) => return content.render(),
             Ok(None) => "".to_string(),
             Err(_) => "".to_string(),
         };

--- a/src/template.rs
+++ b/src/template.rs
@@ -12,6 +12,7 @@ pub mod django_rusty_templates {
 
     use crate::loaders::{AppDirsLoader, CachedLoader, FileSystemLoader, Loader};
     use crate::parse::{Parser, TokenTree};
+    use crate::render::Render;
 
     import_exception_bound!(django.core.exceptions, ImproperlyConfigured);
     import_exception_bound!(django.template.exceptions, TemplateDoesNotExist);


### PR DESCRIPTION
Refactor the `Filter` enum into a `Filter` struct and `FilterType` enum. This allows `at` and `left` to be required for each filter variant, but the `right` argument to be required, forbidden or optional depending on the filter variant. This is encoded in the `FilterType` enum.

The `right` argument is now an instance of `Argument`, which allows better error reporting for `ParseError::MissingArgument` and splits apart the `Argument` and `TokenTree` types, where before the `TokenTree` was overloaded.

Add a `Render` trait to standardise the resolving and rendering of `TokenTree` variants.