### PR TITLE
Implement autoescape for variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,7 @@ name = "django-rusty-templates"
 version = "0.1.0"
 dependencies = [
  "encoding_rs",
+ "html-escape",
  "miette",
  "num-bigint",
  "pyo3",
@@ -134,6 +135,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
 
 [[package]]
 name = "indoc"
@@ -630,6 +640,12 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 encoding_rs = "0.8.35"
+html-escape = "0.2.13"
 miette = { version = "7.2.0", features = ["fancy"] }
 num-bigint = "0.4.6"
 pyo3 = { version = "0.23.3", features = ["num-bigint"] }

--- a/tests/test_autoescape.py
+++ b/tests/test_autoescape.py
@@ -1,0 +1,75 @@
+import pytest
+from django.template import engines
+from django.utils.safestring import mark_safe
+
+
+def test_mark_safe():
+    html = mark_safe("<p>Hello World!</p>")
+    template = "{{ html }}"
+    django_template = engines["django"].from_string(template)
+    rust_template = engines["rusty"].from_string(template)
+
+    expected = "<p>Hello World!</p>"
+    assert django_template.render({"html": html}) == expected
+    assert rust_template.render({"html": html}) == expected
+
+
+def test_autoescape():
+    html = "<p>Hello World!</p>"
+    template = "{{ html }}"
+    django_template = engines["django"].from_string(template)
+    rust_template = engines["rusty"].from_string(template)
+
+    expected = "&lt;p&gt;Hello World!&lt;/p&gt;"
+    assert django_template.render({"html": html}) == expected
+    assert rust_template.render({"html": html}) == expected
+
+
+def test_autoescape_not_string():
+    class Html:
+        def __init__(self, html):
+            self.html = html
+
+        def __str__(self):
+            return self.html
+
+    html = Html("<p>Hello World!</p>")
+    template = "{{ html }}"
+    django_template = engines["django"].from_string(template)
+    rust_template = engines["rusty"].from_string(template)
+
+    expected = "&lt;p&gt;Hello World!&lt;/p&gt;"
+    assert django_template.render({"html": html}) == expected
+    assert rust_template.render({"html": html}) == expected
+
+
+def test_autoescape_invalid_str_method():
+    class Broken:
+        def __str__(self):
+            1/0
+
+    broken = Broken()
+    template = "{{ broken }}"
+    django_template = engines["django"].from_string(template)
+    rust_template = engines["rusty"].from_string(template)
+
+    with pytest.raises(ZeroDivisionError):
+        django_template.render({"broken": broken})
+    with pytest.raises(ZeroDivisionError):
+        rust_template.render({"broken": broken})
+
+
+def test_autoescape_invalid_html_method():
+    class Broken(str):
+        def __html__(self):
+            1/0
+
+    broken = Broken("")
+    template = "{{ broken }}"
+    django_template = engines["django"].from_string(template)
+    rust_template = engines["rusty"].from_string(template)
+
+    with pytest.raises(ZeroDivisionError):
+        django_template.render({"broken": broken})
+    with pytest.raises(ZeroDivisionError):
+        rust_template.render({"broken": broken})


### PR DESCRIPTION
Use `html_escape::encode_quoted_attribute` because this escapes the same characters (`&<>"'`) as Python's `html.escape(quote=True)`, which Django uses.

https://docs.rs/html-escape/latest/html_escape/fn.encode_quoted_attribute.html https://docs.python.org/3/library/html.html#html.escape https://github.com/django/django/blob/8d9901c961bf9d5cfa6bddddbbcebfbf487a5125/django/utils/html.py#L57

Store the `autoescape` value on `Template` to avoid needing to store the entire `engine` instance.