### PR TITLE
Adding addslashes as a new filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ source .venv/bin/activate
 $ pip install -r requirements.txt
 ```
 
-To run the Python tests, build Django Rusty Templates in develop mode with maturin and then run pytest:
+To run the Python tests, build Django Rusty Templates in develop mode with maturin and then run pytest. Each change in rust needs a new execution of maturin develop.
 
 ```bash
 $ maturin develop

--- a/src/render.rs
+++ b/src/render.rs
@@ -233,9 +233,9 @@ impl Render for Filter {
                 Some(content) => Some(Content::String(Cow::Owned(
                     content
                         .render(context)?
-                        .replace("\\", "\\\\")
+                        .replace(r"\", r"\\")
                         .replace("\"", "\\\"")
-                        .replace("'", "\\'"),
+                        .replace("'", r"\'"),
                 ))),
                 None => Some(Content::String(Cow::Borrowed(""))),
             },

--- a/src/render.rs
+++ b/src/render.rs
@@ -583,7 +583,7 @@ user = User('Lily')
             };
 
             let rendered = filter.render(py, template, &mut context).unwrap();
-            assert_eq!(rendered, "\\'hello\\'");
+            assert_eq!(rendered, r"\'hello\'");
         })
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -211,6 +211,8 @@ pub mod django_rusty_templates {
         pub fn from_string(&self, template_code: Bound<'_, PyString>) -> PyResult<Template> {
             Template::new_from_string(template_code.py(), template_code.extract()?, &self.data)
         }
+
+        // TODO render_to_string needs implementation.
     }
 
     #[derive(Debug)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+from django.template import engines
+
+
+@pytest.fixture
+def rusty():
+    return engines["rusty"].from_string
+
+
+@pytest.fixture
+def django_temp():
+    return engines["django"].from_string
+
+
+@pytest.fixture
+def assert_render(rusty, django_temp):
+    def temp(template, context, expected):
+        assert django_temp(template).render(context) == expected
+        assert rusty(template).render(context) == expected
+
+    return temp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,14 +8,14 @@ def rusty():
 
 
 @pytest.fixture
-def django_temp():
+def django_template():
     return engines["django"].from_string
 
 
 @pytest.fixture
-def assert_render(rusty, django_temp):
-    def temp(template, context, expected):
-        assert django_temp(template).render(context) == expected
+def assert_render(rusty, django_template):
+    def assert_render_template(template, context, expected):
+        assert django_template(template).render(context) == expected
         assert rusty(template).render(context) == expected
 
-    return temp
+    return assert_render_template

--- a/tests/filters/test_addslashes.py
+++ b/tests/filters/test_addslashes.py
@@ -1,0 +1,63 @@
+"""
+Test cases adapted from
+https://github.com/django/django/blob/main/tests/template_tests/filter_tests/test_addslashes.py
+"""
+
+import pytest
+from django.template import engines
+from django.utils.safestring import mark_safe
+
+
+@pytest.mark.xfail(reason="autoescape not there yet")
+def test_addslashes01(self):
+    """
+    @setup(
+        {
+            "addslashes01": (
+                "{% autoescape off %}{{ a|addslashes }} {{ b|addslashes }}"
+                "{% endautoescape %}"
+            )
+        }
+    )
+    """
+    output = self.engine.render_to_string(
+        "addslashes01", {"a": "<a>'", "b": mark_safe("<a>'")}
+    )
+    self.assertEqual(output, r"<a>\' <a>\'")
+
+
+@pytest.mark.xfail(reason="autoescape not there yet")
+def test_addslashes02(self):
+    """@setup({"addslashes02": "{{ a|addslashes }} {{ b|addslashes }}"})"""
+    template = "{{ a|addslashes }} {{ b|addslashes }}"
+
+    django_template = engines["django"].from_string(template)
+    rust_template = engines["rusty"].from_string(template)
+
+    output = self.engine.render_to_string(
+        "addslashes02", {"a": "<a>'", "b": mark_safe("<a>'")}
+    )
+    self.assertEqual(output, r"&lt;a&gt;\&#x27; <a>\'")
+
+
+def test_quotes(assert_render):
+    template = "{{ a|addslashes }} and {{ b|addslashes }}"
+    expected = "\\\"double quotes\\\" and \\'single quotes\\'"
+    context = {"a": mark_safe('"double quotes"'), "b": mark_safe("'single quotes'")}
+
+    assert_render(template, context, expected)
+
+
+def test_backslashes(assert_render):
+    template = "{{ a|addslashes }}"
+    context = {"a": r"\ : backslashes, too"}
+    expected = "\\\\ : backslashes, too"
+
+    assert_render(template, context, expected)
+
+
+def test_non_string_input(assert_render):
+    template = "{{ a|addslashes }}"
+    context = {"a": 123}
+
+    assert_render(template, context, "123")

--- a/tests/filters/test_addslashes.py
+++ b/tests/filters/test_addslashes.py
@@ -42,7 +42,7 @@ def test_addslashes02(self):
 
 def test_quotes(assert_render):
     template = "{{ a|addslashes }} and {{ b|addslashes }}"
-    expected = "\\\"double quotes\\\" and \\'single quotes\\'"
+    expected = r"\"double quotes\" and \'single quotes\'"
     context = {"a": mark_safe('"double quotes"'), "b": mark_safe("'single quotes'")}
 
     assert_render(template, context, expected)
@@ -51,7 +51,7 @@ def test_quotes(assert_render):
 def test_backslashes(assert_render):
     template = "{{ a|addslashes }}"
     context = {"a": r"\ : backslashes, too"}
-    expected = "\\\\ : backslashes, too"
+    expected = r"\\ : backslashes, too"
 
     assert_render(template, context, expected)
 


### PR DESCRIPTION
Here is my attempt at adding the `addslashes` filter. Haven't worked with rust a lot. So please feel free to share anything that is worth keeping in mind while getting better at rust. 

I added a fixture `assert_render` that wraps the template rendering for a consistent experience going forward for that kind of tests.  