### PR TITLE
Skip 100% covered Python files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+
+skip_covered = True


### PR DESCRIPTION
This keeps the coverage report focussed on files without coverage.