### PR TITLE
Use ruff linting; F811 will prevent duplicate test function names

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,6 +37,9 @@ jobs:
       run: |
         source <(cargo llvm-cov show-env --export-prefix)
         .venv/bin/maturin develop
+    - name: Lint test files
+      run: |
+        .venv/bin/ruff check
     - name: Test with pytest
       run: |
         source <(cargo llvm-cov show-env --export-prefix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,14 @@ python-source = "python"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.settings"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []

--- a/python/django_rusty_templates/__init__.py
+++ b/python/django_rusty_templates/__init__.py
@@ -4,6 +4,8 @@ from django.template.backends.django import get_installed_libraries
 
 from .django_rusty_templates import Engine, Template
 
+__all__ = [Engine, Template]
+
 
 class RustyTemplates(BaseEngine):
     app_dirname = "templates"

--- a/python/django_rusty_templates/__init__.py
+++ b/python/django_rusty_templates/__init__.py
@@ -4,7 +4,7 @@ from django.template.backends.django import get_installed_libraries
 
 from .django_rusty_templates import Engine, Template
 
-__all__ = [Engine, Template]
+__all__ = ["RustyTemplates", "Template"]
 
 
 class RustyTemplates(BaseEngine):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django
 maturin
 pytest
 pytest-django
+ruff

--- a/tests/filters/test_add.py
+++ b/tests/filters/test_add.py
@@ -1,7 +1,7 @@
 import pytest
 from django.template import engines
-from django.template.exceptions import TemplateSyntaxError
 from django.template.base import VariableDoesNotExist
+from django.template.exceptions import TemplateSyntaxError
 
 
 def test_add_integers():
@@ -121,12 +121,12 @@ def test_add_missing_argument():
     template = "{{ foo|add }}"
 
     with pytest.raises(TemplateSyntaxError) as exc_info:
-        django_template = engines["django"].from_string(template)
+        engines["django"].from_string(template)
 
     assert str(exc_info.value) == "add requires 2 arguments, 1 provided"
 
     with pytest.raises(TemplateSyntaxError) as exc_info:
-        rust_template = engines["rusty"].from_string(template)
+        engines["rusty"].from_string(template)
 
     assert str(exc_info.value) == """
   × Expected an argument

--- a/tests/filters/test_addslashes.py
+++ b/tests/filters/test_addslashes.py
@@ -4,7 +4,6 @@ https://github.com/django/django/blob/main/tests/template_tests/filter_tests/tes
 """
 
 import pytest
-from django.template import engines
 from django.utils.safestring import mark_safe
 
 
@@ -31,8 +30,8 @@ def test_addslashes02(self):
     """@setup({"addslashes02": "{{ a|addslashes }} {{ b|addslashes }}"})"""
     template = "{{ a|addslashes }} {{ b|addslashes }}"
 
-    django_template = engines["django"].from_string(template)
-    rust_template = engines["rusty"].from_string(template)
+    django_template = engines["django"].from_string(template)  # noqa
+    rust_template = engines["rusty"].from_string(template)  # noqa
 
     output = self.engine.render_to_string(
         "addslashes02", {"a": "<a>'", "b": mark_safe("<a>'")}

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from textwrap import dedent
 
 import pytest
 from django.template import engines


### PR DESCRIPTION
Here we use linting to check that we don't get any duplicate function names in tests. [Specifically F811](https://docs.astral.sh/ruff/rules/#pyflakes-f) covers this. 

We get some other linting for free, and have the possibility to expand on linting rules if we want. 

So in that sense, perhaps using coverage for python test_*.py becomes redundant? 