### PR TITLE
Add the slugify filter 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,11 @@ dependencies = [
  "num-bigint",
  "pyo3",
  "quickcheck",
+ "regex",
  "sugar_path",
  "temp-env",
  "thiserror 2.0.11",
+ "unicode-normalization",
  "unicode-xid",
 ]
 
@@ -925,6 +927,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +974,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ pyo3 = { version = "0.23.3", features = ["num-bigint"] }
 sugar_path = "1.2.0"
 thiserror = "2.0.9"
 unicode-xid = "0.2.6"
+regex = "1.11.1"
+unicode-normalization = "0.1.24"
 
 [dev-dependencies]
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -12,6 +12,7 @@ pub enum FilterType {
     External(ExternalFilter),
     Lower(LowerFilter),
     Safe(SafeFilter),
+    Slugify(SlugifyFilter),
 }
 
 #[derive(Debug)]
@@ -62,3 +63,6 @@ pub struct LowerFilter;
 
 #[derive(Debug)]
 pub struct SafeFilter;
+
+#[derive(Debug)]
+pub struct SlugifyFilter;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -150,6 +150,7 @@ impl PyEq for FilterType {
             }
             (Self::Lower(_), Self::Lower(_)) => true,
             (Self::Safe(_), Self::Safe(_)) => true,
+            (Self::Slugify(_), Self::Slugify(_)) => true,
             _ => false,
         }
     }
@@ -206,7 +207,7 @@ impl Filter {
                 None => FilterType::Safe(SafeFilter),
             },
             "slugify" => match right {
-                Some(right) => return Err(unexpected_argument("safe", right)),
+                Some(right) => return Err(unexpected_argument("slugify", right)),
                 None => FilterType::Slugify(SlugifyFilter),
             },
             external => {
@@ -1744,6 +1745,11 @@ mod tests {
             let cloned = escape.clone_ref(py);
             assert_eq!(escape, cloned);
             assert!(escape.py_eq(&cloned, py));
+
+            let slugify = FilterType::Slugify(SlugifyFilter);
+            let cloned = slugify.clone_ref(py);
+            assert_eq!(slugify, cloned);
+            assert!(slugify.py_eq(&cloned, py));
         })
     }
 

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -267,14 +267,14 @@ impl ResolveFilter for SlugifyFilter {
         variable: Option<Content<'t, 'py>>,
         py: Python<'py>,
         _template: TemplateString<'t>,
-        context: &mut Context,
+        _context: &mut Context,
     ) -> ResolveResult<'t, 'py> {
         let non_word_re = Regex::new(r"[^\w\s-]").unwrap();
         let whitespace_re = Regex::new(r"[-\s]+").unwrap();
 
         let content = match variable {
             Some(content) => {
-                let content = content.resolve_string(context)?.content();
+                let content = content.to_py(py)?.str()?.extract::<String>()?;
                 let content = content
                     .nfkd()
                     // first decomposing characters, then only keeping

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -402,6 +402,15 @@ mod tests {
             assert_eq!(result, "a-b");
 
             let engine = EngineData::empty();
+            let template_string = "{{ var|slugify }}".to_string();
+            let context = PyDict::new(py);
+            context.set_item("var", 1).unwrap();
+            let template = Template::new_from_string(py, template_string, &engine).unwrap();
+            let result = template.render(py, Some(context), None).unwrap();
+
+            assert_eq!(result, "1");
+
+            let engine = EngineData::empty();
             let template_string = "{{ not_there|slugify }}".to_string();
             let context = PyDict::new(py);
             let template = Template::new_from_string(py, template_string, &engine).unwrap();

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -402,9 +402,8 @@ mod tests {
             assert_eq!(result, "a-b");
 
             let engine = EngineData::empty();
-            let template_string = "{{ var|slugify }}".to_string();
+            let template_string = "{{ var|default:1|slugify }}".to_string();
             let context = PyDict::new(py);
-            context.set_item("var", 1).unwrap();
             let template = Template::new_from_string(py, template_string, &engine).unwrap();
             let result = template.render(py, Some(context), None).unwrap();
 

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -374,6 +374,20 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "a-b");
+
+            let engine = EngineData::empty();
+            let template_string = "{{ not_there|slugify }}".to_string();
+            let context = PyDict::new(py);
+            let template = Template::new_from_string(py, template_string, &engine).unwrap();
+            let result = template.render(py, Some(context), None).unwrap();
+
+            assert_eq!(result, "");
+
+            let template_string = "{{ var|slugify:invalid }}".to_string();
+            let error = Template::new_from_string(py, template_string, &engine).unwrap_err();
+
+            let error_string = format!("{error}");
+            assert!(error_string.contains("slugify filter does not take an argument"));
         })
     }
 

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -377,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_filter_slugify() {
+    fn test_render_filter_slugify_happy_path() {
         pyo3::prepare_freethreaded_python();
 
         Python::with_gil(|py| {
@@ -389,7 +389,14 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "hello-world");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_spaces_omitted() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
             let engine = EngineData::empty();
             let template_string = "{{ var|slugify }}".to_string();
             let context = PyDict::new(py);
@@ -398,7 +405,14 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "hello-world");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_special_characters_omitted() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
             let engine = EngineData::empty();
             let template_string = "{{ var|slugify }}".to_string();
             let context = PyDict::new(py);
@@ -407,7 +421,14 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "a");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_multiple_spaces_inside_becomes_single() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
             let engine = EngineData::empty();
             let template_string = "{{ var|slugify }}".to_string();
             let context = PyDict::new(py);
@@ -416,7 +437,14 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "a-b");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_integer() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
             let engine = EngineData::empty();
             let template_string = "{{ var|default:1|slugify }}".to_string();
             let context = PyDict::new(py);
@@ -424,7 +452,14 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "1");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_float() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
             let engine = EngineData::empty();
             let template_string = "{{ var|default:1.3|slugify }}".to_string();
             let context = PyDict::new(py);
@@ -432,7 +467,14 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "1.3");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_rust_string() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
             let engine = EngineData::empty();
             let template_string = "{{ var|default:'hello world'|slugify }}".to_string();
             let context = PyDict::new(py);
@@ -440,7 +482,14 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "hello-world");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_safe_string() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
             let engine = EngineData::empty();
             let template_string = "{{ var|default:'hello world'|safe|slugify }}".to_string();
             let context = PyDict::new(py);
@@ -448,7 +497,14 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "hello-world");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_safe_string_from_rust_treated_as_py() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
             let engine = EngineData::empty();
             let template_string = "{{ var|slugify }}".to_string();
             let context = PyDict::new(py);
@@ -458,7 +514,14 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "a-amp-b");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_non_existing_variable() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
             let engine = EngineData::empty();
             let template_string = "{{ not_there|slugify }}".to_string();
             let context = PyDict::new(py);
@@ -466,7 +529,15 @@ mod tests {
             let result = template.render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "");
+        })
+    }
 
+    #[test]
+    fn test_render_filter_slugify_invalid() {
+        pyo3::prepare_freethreaded_python();
+
+        Python::with_gil(|py| {
+            let engine = EngineData::empty();
             let template_string = "{{ var|slugify:invalid }}".to_string();
             let error = Template::new_from_string(py, template_string, &engine).unwrap_err();
 

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 
 use crate::filters::{
     AddFilter, AddSlashesFilter, CapfirstFilter, DefaultFilter, EscapeFilter, ExternalFilter,
-    FilterType, LowerFilter, SafeFilter,
+    FilterType, LowerFilter, SafeFilter, SlugifyFilter,
 };
 use crate::parse::Filter;
 use crate::render::types::{Content, Context};
@@ -55,6 +55,7 @@ impl Resolve for Filter {
             FilterType::External(filter) => filter.resolve(left, py, template, context),
             FilterType::Lower(filter) => filter.resolve(left, py, template, context),
             FilterType::Safe(filter) => filter.resolve(left, py, template, context),
+            FilterType::Slugify(filter) => filter.resolve(left, py, template, context),
         };
         result
     }
@@ -255,6 +256,18 @@ impl ResolveFilter for SafeFilter {
             None => Some(Content::HtmlSafe(Cow::Borrowed(""))),
         };
         Ok(content)
+    }
+}
+
+impl ResolveFilter for SlugifyFilter {
+    fn resolve<'t, 'py>(
+        &self,
+        variable: Option<Content<'t, 'py>>,
+        _py: Python<'py>,
+        _template: TemplateString<'t>,
+        context: &mut Context,
+    ) -> ResolveResult<'t, 'py> {
+        Ok("".as_content())
     }
 }
 

--- a/src/render/types.rs
+++ b/src/render/types.rs
@@ -24,7 +24,7 @@ pub enum ContentString<'t> {
 
 #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust-clippy/issues/13923
 impl<'t, 'py> ContentString<'t> {
-    fn content(self) -> Cow<'t, str> {
+    pub fn content(self) -> Cow<'t, str> {
         match self {
             Self::String(content) => content,
             Self::HtmlSafe(content) => content,

--- a/tests/filters/test_slugify.py
+++ b/tests/filters/test_slugify.py
@@ -75,3 +75,19 @@ def test_danish_name(assert_render):
     expected = "lrke-srensen"
 
     assert_render(template, context, expected)
+
+
+def test_list(assert_render):
+    template = "{{ test|slugify }}"
+    context = {"test": ["hello world", "muu"]}
+    expected = "hello-world-muu"
+
+    assert_render(template, context, expected)
+
+
+def test_dictionary(assert_render):
+    template = "{{ test|slugify }}"
+    context = {"test": {"key": "value"}}
+    expected = "key-value"
+
+    assert_render(template, context, expected)

--- a/tests/filters/test_slugify.py
+++ b/tests/filters/test_slugify.py
@@ -67,3 +67,11 @@ def test_slugify_lazy_string(assert_render):
     }
     expected = "jack-jill-like-numbers-123-and-4-and-silly-characters"
     assert_render(template, context, expected)
+
+
+def test_danish_name(assert_render):
+    template = "{{ test|slugify }}"
+    context = {"test": "Lærke Sørensen"}
+    expected = "lrke-srensen"
+
+    assert_render(template, context, expected)

--- a/tests/filters/test_slugify.py
+++ b/tests/filters/test_slugify.py
@@ -3,28 +3,18 @@ Adapted from
 https://github.com/django/django/blob/5.1/tests/template_tests/filter_tests/test_slugify.py
 """
 
-import pytest
 from django.utils.functional import lazy
 from django.utils.safestring import mark_safe
 
 
-@pytest.mark.xfail(reason="autoescape not ready yet")
-def test_slugify01(self):
+def test_slugify01(assert_render):
     """
     Running slugify on a pre-escaped string leads to odd behavior,
     but the result is still safe.
     """
-    # @setup(
-    #     {
-    #         "slugify01": (
-    #             "{% autoescape off %}{{ a|slugify }} {{ b|slugify }}{% endautoescape %}"
-    #         )
-    #     }
-    # )
-    output = self.engine.render_to_string(
-        "slugify01", {"a": "a & b", "b": mark_safe("a &amp; b")}
-    )
-    self.assertEqual(output, "a-b a-amp-b")
+    template = "{% autoescape off %}{{ a|slugify }} {{ b|slugify }}{% endautoescape %}"
+    context = {"a": "a & b", "b": mark_safe("a &amp; b")}
+    assert_render(template, context, "a-b a-amp-b")
 
 
 def test_slugify02(assert_render):

--- a/tests/filters/test_slugify.py
+++ b/tests/filters/test_slugify.py
@@ -1,0 +1,69 @@
+"""
+Adapted from
+https://github.com/django/django/blob/5.1/tests/template_tests/filter_tests/test_slugify.py
+"""
+
+import pytest
+from django.utils.functional import lazy
+from django.utils.safestring import mark_safe
+
+
+@pytest.mark.xfail(reason="autoescape not ready yet")
+def test_slugify01(self):
+    """
+    Running slugify on a pre-escaped string leads to odd behavior,
+    but the result is still safe.
+    """
+    # @setup(
+    #     {
+    #         "slugify01": (
+    #             "{% autoescape off %}{{ a|slugify }} {{ b|slugify }}{% endautoescape %}"
+    #         )
+    #     }
+    # )
+    output = self.engine.render_to_string(
+        "slugify01", {"a": "a & b", "b": mark_safe("a &amp; b")}
+    )
+    self.assertEqual(output, "a-b a-amp-b")
+
+
+def test_slugify02(assert_render):
+    template = "{{ a|slugify }} {{ b|slugify }}"
+    context = {"a": "a & b", "b": mark_safe("a &amp; b")}
+    assert_render(template, context, "a-b a-amp-b")
+
+
+def test_slugify(assert_render):
+    template = "{{ test|slugify }}"
+    context = {
+        "test": " Jack & Jill like numbers 1,2,3 and 4 and silly characters ?%.$!/"
+    }
+    expected = "jack-jill-like-numbers-123-and-4-and-silly-characters"
+    assert_render(template, context, expected)
+
+
+def test_unicode(assert_render):
+    template = "{{ test|slugify }}"
+    context = {"test": "Un \xe9l\xe9phant \xe0 l'or\xe9e du bois"}
+    expected = "un-elephant-a-loree-du-bois"
+
+    assert_render(template, context, expected)
+
+
+def test_non_string_input(assert_render):
+    template = "{{ test|slugify }}"
+    context = {"test": 123}
+    expected = "123"
+    assert_render(template, context, expected)
+
+
+def test_slugify_lazy_string(assert_render):
+    lazy_str = lazy(lambda string: string, str)
+    template = "{{ test|slugify }}"
+    context = {
+        "test": lazy_str(
+            " Jack & Jill like numbers 1,2,3 and 4 and silly characters ?%.$!/"
+        )
+    }
+    expected = "jack-jill-like-numbers-123-and-4-and-silly-characters"
+    assert_render(template, context, expected)


### PR DESCRIPTION
Supersedes #61 as it was easier to do this in new commits rather than rebase the thing. 

Also an open question regarding file structure. When working through the files I just noticed that we have `render/filters.rs` and `filters.rs`, to me it would make sense to keep this in the same place. Or did you have any particular reasons for splitting that up? 