### PR TITLE
Extract the variables into python types to get into the correct matcharm from the start

### DIFF
--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -446,8 +446,9 @@ mod tests {
 
         Python::with_gil(|py| {
             let engine = EngineData::empty();
-            let template_string = "{{ var|default:1|slugify }}".to_string();
+            let template_string = "{{ var|slugify }}".to_string();
             let context = PyDict::new(py);
+            context.set_item("var", 1).unwrap();
             let template = Template::new_from_string(py, template_string, &engine).unwrap();
             let result = template.render(py, Some(context), None).unwrap();
 

--- a/src/render/types.rs
+++ b/src/render/types.rs
@@ -63,6 +63,17 @@ fn resolve_python<'t>(value: Bound<'_, PyAny>, context: &Context) -> PyResult<Co
     ))
 }
 
+#[derive(Debug, FromPyObject)]
+pub enum PythonTypes<'py> {
+    #[pyo3(transparent)]
+    Int(BigInt),
+    #[pyo3(transparent)]
+    Float(f64),
+    #[pyo3(transparent)]
+    String(String),
+    CatchAll(Bound<'py, PyAny>),
+}
+
 #[derive(Debug, IntoPyObject)]
 pub enum Content<'t, 'py> {
     Py(Bound<'py, PyAny>),


### PR DESCRIPTION
Creating this as a draft PR to check-in with the approach. This does seem to solve #71, as the coverage pattern definitely have changed. 