### PR TITLE
add OSes to workflow matrix for Python and Rust tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,8 +22,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - name: Configure Git line-endings (Windows)
-      if: runner.os == 'Windows'
+    # on Windows, make sure line-endings are consistent for test suite
+    - if: runner.os == 'Windows'
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
@@ -31,15 +31,15 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install gettext for translation testing (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
       run: sudo apt-get install gettext
 
     - name: Install gettext for translation testing (macOS)
-      if: matrix.os == 'macos-latest'
+      if: runner.os == 'macOS'
       run: brew install gettext
 
     - name: Install gettext for translation testing (Windows)
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
       shell: bash
       run: |
         LATEST_URL=$(curl -s "https://api.github.com/repos/vslavik/gettext-tools-windows/releases/latest" |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,10 +11,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -59,11 +59,12 @@ jobs:
         .venv/bin/pip install pytest-cov
     - name: Install dependencies (Windows)
       if: matrix.os == 'windows-latest'
+      shell: bash
       run: |
         python -m venv .venv
-        .venv\Scripts\python -m pip install --upgrade pip
-        .venv\Scripts\pip install -r requirements.txt
-        .venv\Scripts\pip install pytest-cov
+        .venv/Scripts/python -m pip install --upgrade pip
+        .venv/Scripts/pip install -r requirements.txt
+        .venv/Scripts/pip install pytest-cov
     - name: Install Django Rusty Templates (Unix)
       if: matrix.os != 'windows-latest'
       run: |
@@ -82,7 +83,7 @@ jobs:
       run: .venv/bin/python -m django compilemessages
     - name: Build translation files (Windows)
       if: matrix.os == 'windows-latest'
-      run: .venv\Scripts\python -m django compilemessages
+      run: .venv/Scripts/python -m django compilemessages
     - name: Lint test files (Unix)
       if: matrix.os != 'windows-latest'
       run: |
@@ -90,7 +91,7 @@ jobs:
     - name: Lint test files (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        .venv\Scripts\ruff check
+        .venv/Scripts/ruff check
     - name: Test with pytest (Unix)
       if: matrix.os != 'windows-latest'
       run: |
@@ -103,7 +104,7 @@ jobs:
       run: |
         cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
-        .venv\Scripts\pytest --cov --cov-report=xml
+        .venv/Scripts/pytest --cov --cov-report=xml
     - name: Get rust coverage report (Unix)
       if: runner.os != 'Windows'
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,11 +32,6 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
 
-    - name: Setup LLVM coverage environment
-      run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
-        echo "source $(pwd)/llvm-cov-env.sh" >> $GITHUB_ENV
-
     - name: Install dependencies
       run: |
         python -m venv .venv
@@ -45,6 +40,7 @@ jobs:
         .venv/bin/pip install pytest-cov
     - name: Install Django Rusty Templates
       run: |
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
         .venv/bin/maturin develop
     - name: Build translation files
@@ -54,10 +50,12 @@ jobs:
         .venv/bin/ruff check
     - name: Test with pytest
       run: |
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
         .venv/bin/pytest --cov --cov-report=xml
     - name: Get rust coverage report
       run: |
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
         cargo llvm-cov report --codecov --output-path codecov.json
     - name: Upload to codecov

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,6 +32,11 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
 
+    - name: Setup LLVM coverage environment
+      run: |
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        echo "source $(pwd)/llvm-cov-env.sh" >> $GITHUB_ENV
+
     - name: Install dependencies
       run: |
         python -m venv .venv
@@ -40,7 +45,7 @@ jobs:
         .venv/bin/pip install pytest-cov
     - name: Install Django Rusty Templates
       run: |
-        source <(cargo llvm-cov show-env --export-prefix)
+        source llvm-cov-env.sh
         .venv/bin/maturin develop
     - name: Build translation files
       run: .venv/bin/python -m django compilemessages
@@ -49,11 +54,11 @@ jobs:
         .venv/bin/ruff check
     - name: Test with pytest
       run: |
-        source <(cargo llvm-cov show-env --export-prefix)
+        source llvm-cov-env.sh
         .venv/bin/pytest --cov --cov-report=xml
     - name: Get rust coverage report
       run: |
-        source <(cargo llvm-cov show-env --export-prefix)
+        source llvm-cov-env.sh
         cargo llvm-cov report --codecov --output-path codecov.json
     - name: Upload to codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,11 +42,8 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: bash
       run: |
-        LATEST_URL=$(curl -s https://api.github.com/repos/vslavik/gettext-tools-windows/releases/latest |
-          grep "browser_download_url.*zip" |
-          cut -d : -f 2,3 |
-          tr -d \")
-
+        LATEST_URL=$(curl -s "https://api.github.com/repos/vslavik/gettext-tools-windows/releases/latest" |
+          grep -o 'https://github.com/vslavik/gettext-tools-windows/releases/download/[^"]*\.zip')
         curl -L "$LATEST_URL" -o "$RUNNER_TEMP/gettext.zip"
         unzip "$RUNNER_TEMP/gettext.zip" -d "$RUNNER_TEMP/gettext"
         echo "$RUNNER_TEMP/gettext/bin" >> $GITHUB_PATH

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         python -m venv .venv
         echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
-        echo "$(pwd)/.venv/Scripts" >> $GITHUB_PATH
+        echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
 
     - name: Create and activate virtual environment (Windows)
       if: runner.os == 'Windows'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,10 +40,9 @@ jobs:
 
     - name: Install gettext for translation testing (Windows)
       if: runner.os == 'Windows'
-      shell: bash
       run: |
-        LATEST_URL=$(curl -s "https://api.github.com/repos/vslavik/gettext-tools-windows/releases/latest" |
-          grep -o 'https://github.com/vslavik/gettext-tools-windows/releases/download/[^"]*\.zip')
+        LATEST_URL=$(curl -s "https://api.github.com/repos/mlocati/gettext-iconv-windows/releases/latest" |
+          grep -o 'https://github.com/mlocati/gettext-iconv-windows/releases/download/[^"]*-shared-64\.zip')
         curl -L "$LATEST_URL" -o "$RUNNER_TEMP/gettext.zip"
         unzip "$RUNNER_TEMP/gettext.zip" -d "$RUNNER_TEMP/gettext"
         echo "$RUNNER_TEMP/gettext/bin" >> $GITHUB_PATH
@@ -94,7 +93,7 @@ jobs:
       run: |
         cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
-        pytest --cov --cov-report=xml -v
+        pytest --cov --cov-report=xml
 
     - name: Get rust coverage report
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -94,7 +94,7 @@ jobs:
       run: |
         cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
-        pytest --cov --cov-report=xml
+        pytest --cov --cov-report=xml -v
 
     - name: Get rust coverage report
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,15 @@ jobs:
 
     - name: Install gettext for translation testing (Windows)
       if: matrix.os == 'windows-latest'
-      run: choco install gettext
+      run: |
+        $GettextUrl = "https://github.com/vslavik/gettext-tools-windows/releases/download/v0.21.1/gettext-tools-windows-0.21.1.zip"
+        $GettextZip = "$env:TEMP\gettext.zip"
+        $GettextDir = "$env:TEMP\gettext"
+
+        Invoke-WebRequest -Uri $GettextUrl -OutFile $GettextZip
+        Expand-Archive -Path $GettextZip -DestinationPath $GettextDir -Force
+
+        echo "$GettextDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,6 +31,7 @@ jobs:
 
     - name: Install gettext for translation testing (Windows)
       if: matrix.os == 'windows-latest'
+      shell: pwsh
       run: |
         $GettextUrl = "https://github.com/vslavik/gettext-tools-windows/releases/download/v0.21.1/gettext-tools-windows-0.21.1.zip"
         $GettextZip = "$env:TEMP\gettext.zip"
@@ -70,10 +71,11 @@ jobs:
         source llvm-cov-env.sh
         .venv/bin/maturin develop
     - name: Install Django Rusty Templates (Windows)
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
+      shell: pwsh
       run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
-        source llvm-cov-env.sh
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.ps1
+        . .\llvm-cov-env.ps1
         .venv\Scripts\maturin develop
     - name: Build translation files (Unix)
       if: matrix.os != 'windows-latest'
@@ -96,15 +98,24 @@ jobs:
         source llvm-cov-env.sh
         .venv/bin/pytest --cov --cov-report=xml
     - name: Test with pytest (Windows)
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
+      shell: pwsh
       run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
-        source llvm-cov-env.sh
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.ps1
+        . .\llvm-cov-env.ps1
         .venv\Scripts\pytest --cov --cov-report=xml
-    - name: Get rust coverage report
+    - name: Get rust coverage report (Unix)
+      if: runner.os != 'Windows'
       run: |
         cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
+        cargo llvm-cov report --codecov --output-path codecov.json
+    - name: Get rust coverage report (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.ps1
+        . .\llvm-cov-env.ps1
         cargo llvm-cov report --codecov --output-path codecov.json
     - name: Upload to codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,6 +29,10 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: brew install gettext
 
+    - name: Install gettext for translation testing (Windows)
+      if: matrix.os == 'windows-latest'
+      run: choco install gettext
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -37,27 +41,58 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
 
-    - name: Install dependencies
+    - name: Install dependencies (Unix)
+      if: matrix.os != 'windows-latest'
       run: |
         python -m venv .venv
         .venv/bin/python -m pip install --upgrade pip
         .venv/bin/pip install -r requirements.txt
         .venv/bin/pip install pytest-cov
-    - name: Install Django Rusty Templates
+    - name: Install dependencies (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        python -m venv .venv
+        .venv\Scripts\python -m pip install --upgrade pip
+        .venv\Scripts\pip install -r requirements.txt
+        .venv\Scripts\pip install pytest-cov
+    - name: Install Django Rusty Templates (Unix)
+      if: matrix.os != 'windows-latest'
       run: |
         cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
         .venv/bin/maturin develop
-    - name: Build translation files
+    - name: Install Django Rusty Templates (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        source llvm-cov-env.sh
+        .venv\Scripts\maturin develop
+    - name: Build translation files (Unix)
+      if: matrix.os != 'windows-latest'
       run: .venv/bin/python -m django compilemessages
-    - name: Lint test files
+    - name: Build translation files (Windows)
+      if: matrix.os == 'windows-latest'
+      run: .venv\Scripts\python -m django compilemessages
+    - name: Lint test files (Unix)
+      if: matrix.os != 'windows-latest'
       run: |
         .venv/bin/ruff check
-    - name: Test with pytest
+    - name: Lint test files (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        .venv\Scripts\ruff check
+    - name: Test with pytest (Unix)
+      if: matrix.os != 'windows-latest'
       run: |
         cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
         .venv/bin/pytest --cov --cov-report=xml
+    - name: Test with pytest (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        source llvm-cov-env.sh
+        .venv\Scripts\pytest --cov --cov-report=xml
     - name: Get rust coverage report
       run: |
         cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,6 +19,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
+    - name: Configure Git (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
     - uses: actions/checkout@v4
 
     - name: Install gettext for translation testing (Ubuntu)

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,6 +12,9 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -19,7 +22,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - name: Configure Git (Windows)
+    - name: Configure Git line-endings (Windows)
       if: runner.os == 'Windows'
       run: |
         git config --global core.autocrlf false
@@ -37,16 +40,16 @@ jobs:
 
     - name: Install gettext for translation testing (Windows)
       if: matrix.os == 'windows-latest'
-      shell: pwsh
+      shell: bash
       run: |
-        $GettextUrl = "https://github.com/vslavik/gettext-tools-windows/releases/download/v0.21.1/gettext-tools-windows-0.21.1.zip"
-        $GettextZip = "$env:TEMP\gettext.zip"
-        $GettextDir = "$env:TEMP\gettext"
+        LATEST_URL=$(curl -s https://api.github.com/repos/vslavik/gettext-tools-windows/releases/latest |
+          grep "browser_download_url.*zip" |
+          cut -d : -f 2,3 |
+          tr -d \")
 
-        Invoke-WebRequest -Uri $GettextUrl -OutFile $GettextZip
-        Expand-Archive -Path $GettextZip -DestinationPath $GettextDir -Force
-
-        echo "$GettextDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+        curl -L "$LATEST_URL" -o "$RUNNER_TEMP/gettext.zip"
+        unzip "$RUNNER_TEMP/gettext.zip" -d "$RUNNER_TEMP/gettext"
+        echo "$RUNNER_TEMP/gettext/bin" >> $GITHUB_PATH
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
@@ -56,74 +59,52 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
 
-    - name: Install dependencies (Unix)
-      if: matrix.os != 'windows-latest'
-      run: |
-        python -m venv .venv
-        .venv/bin/python -m pip install --upgrade pip
-        .venv/bin/pip install -r requirements.txt
-        .venv/bin/pip install pytest-cov
-    - name: Install dependencies (Windows)
-      if: matrix.os == 'windows-latest'
-      shell: bash
-      run: |
-        python -m venv .venv
-        .venv/Scripts/python -m pip install --upgrade pip
-        .venv/Scripts/pip install -r requirements.txt
-        .venv/Scripts/pip install pytest-cov
-    - name: Install Django Rusty Templates (Unix)
-      if: matrix.os != 'windows-latest'
-      run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
-        source llvm-cov-env.sh
-        .venv/bin/maturin develop
-    - name: Install Django Rusty Templates (Windows)
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
-        source llvm-cov-env.sh
-        .venv/Scripts/maturin develop
-    - name: Build translation files (Unix)
-      if: matrix.os != 'windows-latest'
-      run: .venv/bin/python -m django compilemessages
-    - name: Build translation files (Windows)
-      if: matrix.os == 'windows-latest'
-      run: .venv/Scripts/python -m django compilemessages
-    - name: Lint test files (Unix)
-      if: matrix.os != 'windows-latest'
-      run: |
-        .venv/bin/ruff check
-    - name: Lint test files (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        .venv/Scripts/ruff check
-    - name: Test with pytest (Unix)
-      if: matrix.os != 'windows-latest'
-      run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
-        source llvm-cov-env.sh
-        .venv/bin/pytest --cov --cov-report=xml
-    - name: Test with pytest (Windows)
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
-        source llvm-cov-env.sh
-        .venv/Scripts/pytest --cov --cov-report=xml
-    - name: Get rust coverage report (Unix)
+    - name: Create and activate virtual environment (Unix)
       if: runner.os != 'Windows'
       run: |
+        python -m venv .venv
+        echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
+        echo "$(pwd)/.venv/Scripts" >> $GITHUB_PATH
+
+    - name: Create and activate virtual environment (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        python -m venv .venv
+        echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
+        echo "$(pwd)/.venv/Scripts" >> $GITHUB_PATH
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+        python -m pip install pytest-cov
+
+    - name: Install Django Rusty Templates
+      run: |
         cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
-        cargo llvm-cov report --codecov --output-path codecov.json
-    - name: Get rust coverage report (Windows)
-      if: runner.os == 'Windows'
-      shell: bash
+        maturin develop
+
+    - name: Build translation files
+      run: |
+        python -m django compilemessages
+
+    - name: Lint test files
+      run: |
+        ruff check
+
+    - name: Test with pytest
+      run: |
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        source llvm-cov-env.sh
+        pytest --cov --cov-report=xml
+
+    - name: Get rust coverage report
       run: |
         cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
         source llvm-cov-env.sh
         cargo llvm-cov report --codecov --output-path codecov.json
+
     - name: Upload to codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,8 +21,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install gettext for translation testing
+    - name: Install gettext for translation testing (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install gettext
+
+    - name: Install gettext for translation testing (macOS)
+      if: matrix.os == 'macos-latest'
+      run: brew install gettext
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -72,11 +72,11 @@ jobs:
         .venv/bin/maturin develop
     - name: Install Django Rusty Templates (Windows)
       if: runner.os == 'Windows'
-      shell: pwsh
+      shell: bash
       run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.ps1
-        . .\llvm-cov-env.ps1
-        .venv\Scripts\maturin develop
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        source llvm-cov-env.sh
+        .venv/Scripts/maturin develop
     - name: Build translation files (Unix)
       if: matrix.os != 'windows-latest'
       run: .venv/bin/python -m django compilemessages
@@ -99,10 +99,10 @@ jobs:
         .venv/bin/pytest --cov --cov-report=xml
     - name: Test with pytest (Windows)
       if: runner.os == 'Windows'
-      shell: pwsh
+      shell: bash
       run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.ps1
-        . .\llvm-cov-env.ps1
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        source llvm-cov-env.sh
         .venv\Scripts\pytest --cov --cov-report=xml
     - name: Get rust coverage report (Unix)
       if: runner.os != 'Windows'
@@ -112,10 +112,10 @@ jobs:
         cargo llvm-cov report --codecov --output-path codecov.json
     - name: Get rust coverage report (Windows)
       if: runner.os == 'Windows'
-      shell: pwsh
+      shell: bash
       run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.ps1
-        . .\llvm-cov-env.ps1
+        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        source llvm-cov-env.sh
         cargo llvm-cov report --codecov --output-path codecov.json
     - name: Upload to codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,11 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
 
     steps:
     - uses: actions/checkout@v4

--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -682,7 +682,10 @@ mod tests {
     fn test_safe_join_absolute() {
         let path = PathBuf::from("/abc/");
         let joined = safe_join(&path, "def").unwrap();
+        #[cfg(not(windows))]
         assert_eq!(joined, PathBuf::from("/abc/def"));
+        #[cfg(windows)]
+        assert!(joined.ends_with("\\abc\\def"));
     }
 
     #[test]
@@ -777,6 +780,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        windows,
+        ignore = "Skipping on Windows due to path character restrictions"
+    )]
     fn test_safe_join_matches_django_safe_join() {
         pyo3::prepare_freethreaded_python();
 

--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -290,7 +290,10 @@ mod tests {
                 .unwrap();
 
             let mut expected = std::env::current_dir().unwrap();
+            #[cfg(not(windows))]
             expected.push("tests/templates/basic.txt");
+            #[cfg(windows)]
+            expected.push("tests\\templates\\basic.txt");
             assert_eq!(template.filename.unwrap(), expected);
         })
     }
@@ -306,7 +309,10 @@ mod tests {
             let error = loader.get_template(py, "missing.txt", &engine).unwrap_err();
 
             let mut expected = std::env::current_dir().unwrap();
+            #[cfg(not(windows))]
             expected.push("tests/templates/missing.txt");
+            #[cfg(windows)]
+            expected.push("tests\\templates\\missing.txt");
             assert_eq!(
                 error,
                 LoaderError {
@@ -333,7 +339,10 @@ mod tests {
                 .unwrap_err();
 
             let mut expected = std::env::current_dir().unwrap();
+            #[cfg(not(windows))]
             expected.push("tests/templates/invalid.txt");
+            #[cfg(windows)]
+            expected.push("tests\\templates\\invalid.txt");
             assert_eq!(
                 error.to_string(),
                 format!("UnicodeError: Could not open {expected:?} with UTF-8 encoding.")
@@ -375,7 +384,10 @@ mod tests {
             // Verify the template filename
             let mut expected_path =
                 std::env::current_dir().expect("Failed to get current directory");
+            #[cfg(not(windows))]
             expected_path.push("tests/templates/basic.txt");
+            #[cfg(windows)]
+            expected_path.push("tests\\templates\\basic.txt");
             assert_eq!(template.filename.unwrap(), expected_path);
 
             // Verify the cache state after first load
@@ -412,7 +424,10 @@ mod tests {
                 .unwrap_err();
 
             let mut expected = std::env::current_dir().unwrap();
+            #[cfg(not(windows))]
             expected.push("tests/templates/missing.txt");
+            #[cfg(windows)]
+            expected.push("tests\\templates\\missing.txt");
             let expected_err = LoaderError {
                 tried: vec![(
                     expected.display().to_string(),
@@ -450,7 +465,10 @@ mod tests {
                 .unwrap_err();
 
             let mut expected = std::env::current_dir().unwrap();
+            #[cfg(not(windows))]
             expected.push("tests/templates/invalid.txt");
+            #[cfg(windows)]
+            expected.push("tests\\templates\\invalid.txt");
             assert_eq!(
                 error.to_string(),
                 format!("UnicodeError: Could not open {expected:?} with UTF-8 encoding.")
@@ -517,7 +535,10 @@ mod tests {
                 .unwrap();
 
             let mut expected = std::env::current_dir().unwrap();
+            #[cfg(not(windows))]
             expected.push("tests/templates/basic.txt");
+            #[cfg(windows)]
+            expected.push("tests\\templates\\basic.txt");
             assert_eq!(template.filename.unwrap(), expected);
         })
     }
@@ -535,7 +556,10 @@ mod tests {
             let error = loader.get_template(py, "missing.txt", &engine).unwrap_err();
 
             let mut expected = std::env::current_dir().unwrap();
+            #[cfg(not(windows))]
             expected.push("tests/templates/missing.txt");
+            #[cfg(windows)]
+            expected.push("tests\\templates\\missing.txt");
             assert_eq!(
                 error,
                 LoaderError {
@@ -564,7 +588,10 @@ mod tests {
                 .unwrap_err();
 
             let mut expected = std::env::current_dir().unwrap();
+            #[cfg(not(windows))]
             expected.push("tests/templates/invalid.txt");
+            #[cfg(windows)]
+            expected.push("tests\\templates\\invalid.txt");
             assert_eq!(
                 error.to_string(),
                 format!("UnicodeError: Could not open {expected:?} with UTF-8 encoding.")

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -20,6 +20,8 @@ def test_parse_error():
         get_template("parse_error.txt", using="rusty")
 
     template_dir = Path("tests/templates").absolute()
+    # normalize path separators for Windows vs Unix differences
+    template_dir_normalized = str(template_dir).replace('\\', '/')
     expected = """\
   × Empty variable tag
    ╭─[%s/parse_error.txt:1:28]
@@ -28,7 +30,7 @@ def test_parse_error():
    ·                              ╰── here
    ╰────
 """
-    assert str(excinfo.value) == expected % template_dir
+    assert str(excinfo.value) == expected % template_dir_normalized
 
 
 def test_parse_error_from_string():

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -20,15 +21,16 @@ def test_parse_error():
         get_template("parse_error.txt", using="rusty")
 
     template_dir = Path("tests/templates").absolute()
+    path_separator = '/' if os.name != 'nt' else '\\'
     expected = """\
   × Empty variable tag
-   ╭─[%s/parse_error.txt:1:28]
+   ╭─[%s%sparse_error.txt:1:28]
  1 │ This is an empty variable: {{ }}
    ·                            ──┬──
    ·                              ╰── here
    ╰────
 """
-    assert str(excinfo.value) == expected % template_dir
+    assert str(excinfo.value) == expected % (template_dir, path_separator)
 
 
 def test_parse_error_from_string():

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -28,7 +28,7 @@ def test_parse_error():
    ·                              ╰── here
    ╰────
 """
-    assert str(excinfo.value) == expected % template_dir
+    assert str(excinfo.value) == expected % template_dir.as_posix()
 
 
 def test_parse_error_from_string():

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -28,7 +28,7 @@ def test_parse_error():
    ·                              ╰── here
    ╰────
 """
-    assert str(excinfo.value) == expected % template_dir.as_posix()
+    assert str(excinfo.value) == expected % template_dir
 
 
 def test_parse_error_from_string():

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -20,8 +20,6 @@ def test_parse_error():
         get_template("parse_error.txt", using="rusty")
 
     template_dir = Path("tests/templates").absolute()
-    # normalize path separators for Windows vs Unix differences
-    template_dir_normalized = str(template_dir).replace('\\', '/')
     expected = """\
   × Empty variable tag
    ╭─[%s/parse_error.txt:1:28]
@@ -30,7 +28,7 @@ def test_parse_error():
    ·                              ╰── here
    ╰────
 """
-    assert str(excinfo.value) == expected % template_dir_normalized
+    assert str(excinfo.value) == expected % template_dir
 
 
 def test_parse_error_from_string():

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -21,7 +21,6 @@ def test_parse_error():
         get_template("parse_error.txt", using="rusty")
 
     template_dir = Path("tests/templates").absolute()
-    path_separator = '/' if os.name != 'nt' else '\\'
     expected = """\
   × Empty variable tag
    ╭─[%s%sparse_error.txt:1:28]
@@ -30,7 +29,7 @@ def test_parse_error():
    ·                              ╰── here
    ╰────
 """
-    assert str(excinfo.value) == expected % (template_dir, path_separator)
+    assert str(excinfo.value) == expected % (template_dir, os.sep)
 
 
 def test_parse_error_from_string():


### PR DESCRIPTION
👋 Hiya!

Took a guess at what you meant about testing on Windows in #26 and added an OS key to the workflow matrix for the two test workflows. I went ahead and added macOS as well, but if that's not desired I can always pare it back to Linux and Windows.

closes #26 